### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fail.yaml
+++ b/.github/workflows/fail.yaml
@@ -2,6 +2,8 @@ name: Force fail
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   cd:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Mi3-14159/GitGazer/security/code-scanning/7](https://github.com/Mi3-14159/GitGazer/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow so that the GITHUB_TOKEN provided to the job has only read access (or none at all, if possible). Since the only step in this job is `run: exit 1`, it does not require access to repository contents, so `permissions: {} ` (no permissions) is the strictest, but some environments recommend at least `contents: read`. 

Place the `permissions` block at either the workflow root (just after `name` and `on`) or under the job definition (`cd`). For consistency and coverage, add it at the workflow root so _all_ jobs in the workflow inherit the same permissions unless overridden. Edit .github/workflows/fail.yaml to insert the block after the `on:` section. No imports or further changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
