### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_auth_lambda.yaml
+++ b/.github/workflows/ci_auth_lambda.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI auth lambda
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Mi3-14159/GitGazer/security/code-scanning/4](https://github.com/Mi3-14159/GitGazer/security/code-scanning/4)

To fix this problem, an explicit `permissions` block should be added to the workflow file to restrict the permissions of the GITHUB_TOKEN. Since the snippet only shows a single job (`ci`) which does not appear to modify repository contents or interact with issues or pull requests, the correct minimal permission is `contents: read`. This permission block can be set at the workflow root level (just after `name` and before `on:`) so that it applies to all jobs in the workflow, or at the job level if different jobs require different permissions. The most straightforward fix is to add the following block under the workflow name at the top:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are required, just the new permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
