### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd_frontend.yaml
+++ b/.github/workflows/cd_frontend.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CD frontend
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Mi3-14159/GitGazer/security/code-scanning/3](https://github.com/Mi3-14159/GitGazer/security/code-scanning/3)

To resolve the problem, the workflow must explicitly declare a minimal permissions block for `GITHUB_TOKEN` usage. The recommended fix is to add a `permissions` section at the workflow root (directly under the `name:` field, before the `on:` key), with appropriate scoping. Since the workflow only checks out code and deploys to AWS (not GitHub), the minimal permissions required are for reading contents. Thus, set `permissions: contents: read` for the entire workflow. No steps or file regions need to be changed other than adding the single permissions block, ideally at the top level so it applies to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
