### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_frontend.yaml
+++ b/.github/workflows/ci_frontend.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI frontend
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Mi3-14159/GitGazer/security/code-scanning/1](https://github.com/Mi3-14159/GitGazer/security/code-scanning/1)

To fix the problem, explicitly set the token permissions to the least privilege required by the workflow. The recommended default is:

```yaml
permissions:
  contents: read
```

This should be added at the root level of the workflow to apply to all jobs, since no step in the workflow requires any write permission. Place this permissions block after the `name:` and before `on:` (for clarity and convention). This change does not affect existing workflow functionality and ensures adherence to security best-practices. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
