### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_processor_lambda.yaml
+++ b/.github/workflows/ci_processor_lambda.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI processor lambda
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Mi3-14159/GitGazer/security/code-scanning/2](https://github.com/Mi3-14159/GitGazer/security/code-scanning/2)

To fix this issue, add a `permissions:` block to the workflow to limit the GITHUB_TOKEN to only those privileges needed by the workflow. For build/test jobs that do not need repository write access, the minimal safe default is `contents: read`. This can be set at the workflow root (so it applies to all jobs unless a job overrides it), or at the job level (`jobs.ci.permissions:`). Since there is only one job (`ci`) and no other jobs shown, it's preferable and more future-proof to set it at the workflow root. Edit `.github/workflows/ci_processor_lambda.yaml` by adding the following block after the workflow `name:` and before the `on:` trigger block:

```yaml
permissions:
  contents: read
```

This change follows best practices and does not alter existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
