### PR TITLE
feat(auth): bind OAuth state to a signed nonce, verify before token e…

### DIFF
--- a/apps/api/src/domains/auth/auth.controller.test.ts
+++ b/apps/api/src/domains/auth/auth.controller.test.ts
@@ -1,7 +1,7 @@
-import {BadRequestError, ForbiddenError} from '@aws-lambda-powertools/event-handler/http';
+import {BadRequestError, ForbiddenError, InternalServerError} from '@aws-lambda-powertools/event-handler/http';
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
 
-const mockConfigGet = vi.fn((key: string): unknown => {
+const defaultConfigGet = (key: string): unknown => {
     switch (key) {
         case 'stateSecret':
             return 'unit-test-state-secret';
@@ -18,7 +18,8 @@ const mockConfigGet = vi.fn((key: string): unknown => {
         default:
             return '';
     }
-});
+};
+const mockConfigGet = vi.fn(defaultConfigGet);
 
 vi.mock('@/shared/config', () => ({
     default: {
@@ -51,6 +52,7 @@ afterAll(() => {
 
 beforeEach(() => {
     mockFetch.mockReset();
+    mockConfigGet.mockImplementation(defaultConfigGet);
 });
 
 describe('mintStateToken / verifyStateToken', () => {
@@ -90,6 +92,26 @@ describe('mintStateToken / verifyStateToken', () => {
         expect(verifyStateToken('not-a-valid-token', 'some-nonce')).toBeNull();
         expect(verifyStateToken('', 'some-nonce')).toBeNull();
         expect(verifyStateToken(undefined, 'some-nonce')).toBeNull();
+    });
+
+    describe('fail closed when stateSecret is not configured', () => {
+        const withEmptyStateSecret = (): void => {
+            mockConfigGet.mockImplementation((key: string) => (key === 'stateSecret' ? '' : defaultConfigGet(key)));
+        };
+
+        it('mintStateToken throws instead of signing with an empty secret', () => {
+            withEmptyStateSecret();
+
+            expect(() => mintStateToken({redirect_url: ALLOWED_ORIGIN})).toThrow(InternalServerError);
+        });
+
+        it('verifyStateToken rejects an otherwise-valid token when the secret is empty', () => {
+            // Mint with a real secret, then verify after the secret is wiped.
+            const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+            withEmptyStateSecret();
+
+            expect(verifyStateToken(token, nonce)).toBeNull();
+        });
     });
 
     describe('expiry', () => {
@@ -215,7 +237,9 @@ describe('handleOAuthCallback', () => {
     });
 
     it('does NOT exchange the code when the state parameter is missing', async () => {
-        const error = await handleOAuthCallback({code: 'auth-code', state: undefined, oauthStateNonce: 'some-nonce'}).catch((e: unknown) => e as Error);
+        const error = await handleOAuthCallback({code: 'auth-code', state: undefined, oauthStateNonce: 'some-nonce'}).catch(
+            (e: unknown) => e as Error,
+        );
 
         expect(error).toBeInstanceOf(BadRequestError);
         expect(mockFetch).not.toHaveBeenCalled();
@@ -229,6 +253,17 @@ describe('handleOAuthCallback', () => {
         const error = await handleOAuthCallback({code: 'auth-code', state: token, oauthStateNonce: nonce}).catch((e: unknown) => e as Error);
 
         expect(error).toBeInstanceOf(BadRequestError);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does NOT exchange the code when the state secret is not configured', async () => {
+        // Mint with a real secret, then wipe it so verification fails closed at the callback.
+        const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+        mockConfigGet.mockImplementation((key: string) => (key === 'stateSecret' ? '' : defaultConfigGet(key)));
+
+        const error = await handleOAuthCallback({code: 'auth-code', state: token, oauthStateNonce: nonce}).catch((e: unknown) => e as Error);
+
+        expect(error).toBeInstanceOf(ForbiddenError);
         expect(mockFetch).not.toHaveBeenCalled();
     });
 });

--- a/apps/api/src/domains/auth/auth.controller.test.ts
+++ b/apps/api/src/domains/auth/auth.controller.test.ts
@@ -1,0 +1,234 @@
+import {BadRequestError, ForbiddenError} from '@aws-lambda-powertools/event-handler/http';
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mockConfigGet = vi.fn((key: string): unknown => {
+    switch (key) {
+        case 'stateSecret':
+            return 'unit-test-state-secret';
+        case 'allowedFrontendOrigins':
+            return ['https://app.example.com'];
+        case 'cognito':
+            return {
+                userPoolId: 'pool-1',
+                clientId: 'client-123',
+                clientSecret: 'cognito-secret',
+                domain: 'auth.example.com',
+                redirectUri: 'https://api.example.com/api/auth/callback',
+            };
+        default:
+            return '';
+    }
+});
+
+vi.mock('@/shared/config', () => ({
+    default: {
+        get: (key: string): unknown => mockConfigGet(key),
+    },
+}));
+
+import {buildLoginRedirect, handleOAuthCallback, mintStateToken, verifyStateToken} from './auth.controller';
+
+const ALLOWED_ORIGIN = 'https://app.example.com';
+
+const mockFetch = vi.fn();
+
+const tokenResponse = (): Response =>
+    new Response(JSON.stringify({access_token: 'a-token', id_token: 'i-token', refresh_token: 'r-token', expires_in: 3600, token_type: 'Bearer'}), {
+        status: 200,
+        headers: {'Content-Type': 'application/json'},
+    });
+
+/** Extract the raw nonce stored in an `oauthState=<nonce>; ...` cookie string. */
+const nonceFromCookie = (cookie: string): string => cookie.split(';')[0].split('=')[1];
+
+beforeAll(() => {
+    vi.stubGlobal('fetch', mockFetch);
+});
+
+afterAll(() => {
+    vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+    mockFetch.mockReset();
+});
+
+describe('mintStateToken / verifyStateToken', () => {
+    it('round-trips a freshly minted token against its nonce', () => {
+        const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+
+        expect(token.split('.')).toHaveLength(2);
+        expect(nonce).toMatch(/^[0-9a-f]{32}$/);
+
+        const decoded = verifyStateToken(token, nonce);
+        expect(decoded).not.toBeNull();
+        expect(decoded?.redirect_url).toBe(ALLOWED_ORIGIN);
+        expect(decoded?.nonce).toBe(nonce);
+    });
+
+    it('rejects a token with a tampered signature', () => {
+        const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+        const [payload] = token.split('.');
+        const forged = `${payload}.deadbeefdeadbeefdeadbeefdeadbeef`;
+
+        expect(verifyStateToken(forged, nonce)).toBeNull();
+    });
+
+    it('rejects a valid token presented with the wrong nonce', () => {
+        const {token} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+
+        expect(verifyStateToken(token, 'a-different-nonce')).toBeNull();
+    });
+
+    it('rejects when the nonce cookie is missing', () => {
+        const {token} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+
+        expect(verifyStateToken(token, null)).toBeNull();
+    });
+
+    it('rejects a malformed token', () => {
+        expect(verifyStateToken('not-a-valid-token', 'some-nonce')).toBeNull();
+        expect(verifyStateToken('', 'some-nonce')).toBeNull();
+        expect(verifyStateToken(undefined, 'some-nonce')).toBeNull();
+    });
+
+    describe('expiry', () => {
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('rejects an expired token', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+            const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+
+            // Advance past the 10-minute TTL.
+            vi.setSystemTime(new Date('2026-01-01T00:10:01Z'));
+            expect(verifyStateToken(token, nonce)).toBeNull();
+        });
+
+        it('accepts a token still within the TTL', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+            const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+
+            vi.setSystemTime(new Date('2026-01-01T00:09:59Z'));
+            expect(verifyStateToken(token, nonce)).not.toBeNull();
+        });
+    });
+});
+
+describe('buildLoginRedirect', () => {
+    it('mints a state cookie and redirects to the Cognito hosted UI with a verifiable state', () => {
+        const {location, stateCookie} = buildLoginRedirect(ALLOWED_ORIGIN);
+
+        const url = new URL(location);
+        expect(url.origin + url.pathname).toBe('https://auth.example.com/oauth2/authorize');
+        expect(url.searchParams.get('client_id')).toBe('client-123');
+        expect(url.searchParams.get('response_type')).toBe('code');
+        expect(url.searchParams.get('redirect_uri')).toBe('https://api.example.com/api/auth/callback');
+        expect(url.searchParams.get('scope')).toContain('openid');
+
+        const state = url.searchParams.get('state');
+        expect(state).toBeTruthy();
+
+        // The state cookie carries the httpOnly nonce that binds the signed state.
+        expect(stateCookie).toContain('oauthState=');
+        expect(stateCookie).toContain('HttpOnly');
+        expect(stateCookie).toContain('Secure');
+        expect(stateCookie).toContain('SameSite=Lax');
+
+        const decoded = verifyStateToken(state ?? undefined, nonceFromCookie(stateCookie));
+        expect(decoded?.redirect_url).toBe(ALLOWED_ORIGIN);
+    });
+
+    it('rejects a missing redirect_url', () => {
+        expect(() => buildLoginRedirect(undefined)).toThrow(BadRequestError);
+    });
+
+    it('rejects a redirect_url whose origin is not allow-listed', () => {
+        expect(() => buildLoginRedirect('https://evil.example.net')).toThrow(BadRequestError);
+    });
+});
+
+describe('handleOAuthCallback', () => {
+    it('exchanges the code exactly once when the state nonce is valid', async () => {
+        const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+        mockFetch.mockResolvedValue(tokenResponse());
+
+        const result = await handleOAuthCallback({code: 'auth-code', state: token, oauthStateNonce: nonce});
+
+        expect(result.redirectUrl).toBe(ALLOWED_ORIGIN);
+        expect(result.cookies.length).toBeGreaterThan(0);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT exchange the code when the state signature is forged', async () => {
+        const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+        const [payload] = token.split('.');
+        const forged = `${payload}.deadbeefdeadbeefdeadbeefdeadbeef`;
+
+        const error = await handleOAuthCallback({code: 'auth-code', state: forged, oauthStateNonce: nonce}).catch((e: unknown) => e as Error);
+
+        expect(error).toBeInstanceOf(ForbiddenError);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does NOT exchange the code when the nonce does not match the cookie', async () => {
+        const {token} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+
+        const error = await handleOAuthCallback({code: 'auth-code', state: token, oauthStateNonce: 'wrong-nonce'}).catch((e: unknown) => e as Error);
+
+        expect(error).toBeInstanceOf(ForbiddenError);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does NOT exchange the code when the nonce cookie is missing', async () => {
+        const {token} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+
+        const error = await handleOAuthCallback({code: 'auth-code', state: token, oauthStateNonce: null}).catch((e: unknown) => e as Error);
+
+        expect(error).toBeInstanceOf(ForbiddenError);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does NOT exchange the code when the state token is expired', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+        const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+        vi.setSystemTime(new Date('2026-01-01T00:10:01Z'));
+
+        const error = await handleOAuthCallback({code: 'auth-code', state: token, oauthStateNonce: nonce}).catch((e: unknown) => e as Error);
+        vi.useRealTimers();
+
+        expect(error).toBeInstanceOf(ForbiddenError);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does NOT exchange the code when the authorization code is missing', async () => {
+        const {token, nonce} = mintStateToken({redirect_url: ALLOWED_ORIGIN});
+
+        const error = await handleOAuthCallback({code: undefined, state: token, oauthStateNonce: nonce}).catch((e: unknown) => e as Error);
+
+        expect(error).toBeInstanceOf(BadRequestError);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does NOT exchange the code when the state parameter is missing', async () => {
+        const error = await handleOAuthCallback({code: 'auth-code', state: undefined, oauthStateNonce: 'some-nonce'}).catch((e: unknown) => e as Error);
+
+        expect(error).toBeInstanceOf(BadRequestError);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects (before exchange) a verified state whose redirect_url origin is not allow-listed', async () => {
+        // A correctly signed token can still carry a disallowed origin; it must be
+        // rejected by validateRedirectUrl before any token exchange happens.
+        const {token, nonce} = mintStateToken({redirect_url: 'https://evil.example.net'});
+
+        const error = await handleOAuthCallback({code: 'auth-code', state: token, oauthStateNonce: nonce}).catch((e: unknown) => e as Error);
+
+        expect(error).toBeInstanceOf(BadRequestError);
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/domains/auth/auth.controller.ts
+++ b/apps/api/src/domains/auth/auth.controller.ts
@@ -137,6 +137,14 @@ const constantTimeEqual = (a: string, b: string): boolean => {
  * (stored in a short-lived httpOnly cookie for callback verification).
  */
 export const mintStateToken = (params: {redirect_url: string}): {token: string; nonce: string} => {
+    const stateSecret = config.get('stateSecret');
+    if (!stateSecret) {
+        // Fail closed: an empty secret makes the state signature forgeable, silently voiding
+        // the login-CSRF protection. Surface the misconfiguration instead of degrading quietly.
+        getLogger().error('OAuth state secret is not configured');
+        throw new InternalServerError('Login is not configured');
+    }
+
     const nonce = randomBytes(16).toString('hex');
     const statePayload: StateTokenPayload = {
         redirect_url: params.redirect_url,
@@ -144,7 +152,6 @@ export const mintStateToken = (params: {redirect_url: string}): {token: string; 
         exp: Math.floor(Date.now() / 1000) + STATE_TOKEN_TTL_SECONDS,
     };
 
-    const stateSecret = config.get('stateSecret');
     const payload = Buffer.from(JSON.stringify(statePayload)).toString('base64url');
     const signature = createHmac('sha256', stateSecret).update(payload).digest('base64url');
     return {token: `${payload}.${signature}`, nonce};
@@ -160,13 +167,19 @@ export const verifyStateToken = (token: string | undefined, nonceFromCookie: str
         return null;
     }
 
+    const stateSecret = config.get('stateSecret');
+    if (!stateSecret) {
+        // Fail closed: without a configured secret no state token can be trusted.
+        getLogger().error('OAuth state secret is not configured');
+        return null;
+    }
+
     const parts = token.split('.');
     if (parts.length !== 2) {
         return null;
     }
     const [payload, signature] = parts;
 
-    const stateSecret = config.get('stateSecret');
     const expectedSignature = createHmac('sha256', stateSecret).update(payload).digest('base64url');
     if (!constantTimeEqual(signature, expectedSignature)) {
         return null;

--- a/apps/api/src/domains/auth/auth.controller.ts
+++ b/apps/api/src/domains/auth/auth.controller.ts
@@ -1,9 +1,10 @@
+import {validateRedirectUrl} from '@/domains/auth/auth.helpers';
 import config from '@/shared/config';
-import {buildAuthCookies, buildClearCookies} from '@/shared/helpers/cookies';
+import {buildAuthCookies, buildClearCookies, buildStateCookie} from '@/shared/helpers/cookies';
 import {getLogger} from '@/shared/logger';
-import {InternalServerError} from '@aws-lambda-powertools/event-handler/http';
+import {BadRequestError, ForbiddenError, InternalServerError} from '@aws-lambda-powertools/event-handler/http';
 import {WSToken} from '@gitgazer/db/types';
-import {createHmac, randomBytes} from 'crypto';
+import {createHash, createHmac, randomBytes, timingSafeEqual} from 'crypto';
 
 type TokenResponse = {
     access_token: string;
@@ -108,4 +109,147 @@ export const generateWsToken = (params: {userId: number; username: string; email
     const payload = Buffer.from(JSON.stringify(tokenPayload)).toString('base64url');
     const signature = createHmac('sha256', wsTokenSecret).update(payload).digest('base64url');
     return `${payload}.${signature}`;
+};
+
+const STATE_TOKEN_TTL_SECONDS = 600; // 10 minutes — must match the state cookie Max-Age
+const COGNITO_OAUTH_SCOPE = 'email openid profile aws.cognito.signin.user.admin';
+
+/**
+ * Decoded payload carried inside the signed OAuth `state` token. `nonce` is also
+ * stored in a short-lived httpOnly cookie and must match it on the callback.
+ */
+type StateTokenPayload = {
+    redirect_url: string;
+    nonce: string;
+    exp: number;
+};
+
+/** Constant-time string comparison. Hashes both sides so length is never leaked. */
+const constantTimeEqual = (a: string, b: string): boolean => {
+    const hashA = createHash('sha256').update(a).digest();
+    const hashB = createHash('sha256').update(b).digest();
+    return timingSafeEqual(hashA, hashB);
+};
+
+/**
+ * Mint a signed, single-use OAuth `state` token bound to a random nonce.
+ * Returns the token (placed in the Cognito `state` parameter) and the nonce
+ * (stored in a short-lived httpOnly cookie for callback verification).
+ */
+export const mintStateToken = (params: {redirect_url: string}): {token: string; nonce: string} => {
+    const nonce = randomBytes(16).toString('hex');
+    const statePayload: StateTokenPayload = {
+        redirect_url: params.redirect_url,
+        nonce,
+        exp: Math.floor(Date.now() / 1000) + STATE_TOKEN_TTL_SECONDS,
+    };
+
+    const stateSecret = config.get('stateSecret');
+    const payload = Buffer.from(JSON.stringify(statePayload)).toString('base64url');
+    const signature = createHmac('sha256', stateSecret).update(payload).digest('base64url');
+    return {token: `${payload}.${signature}`, nonce};
+};
+
+/**
+ * Verify a signed OAuth `state` token against the nonce stored in the httpOnly
+ * cookie. Returns the decoded payload when the signature, expiry and nonce all
+ * check out, otherwise null. All comparisons are constant-time.
+ */
+export const verifyStateToken = (token: string | undefined, nonceFromCookie: string | null): StateTokenPayload | null => {
+    if (!token || !nonceFromCookie) {
+        return null;
+    }
+
+    const parts = token.split('.');
+    if (parts.length !== 2) {
+        return null;
+    }
+    const [payload, signature] = parts;
+
+    const stateSecret = config.get('stateSecret');
+    const expectedSignature = createHmac('sha256', stateSecret).update(payload).digest('base64url');
+    if (!constantTimeEqual(signature, expectedSignature)) {
+        return null;
+    }
+
+    let decoded: StateTokenPayload;
+    try {
+        decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8')) as StateTokenPayload;
+    } catch {
+        return null;
+    }
+
+    if (typeof decoded.exp !== 'number' || decoded.exp < Math.floor(Date.now() / 1000)) {
+        return null;
+    }
+
+    if (typeof decoded.nonce !== 'string' || !constantTimeEqual(decoded.nonce, nonceFromCookie)) {
+        return null;
+    }
+
+    return decoded;
+};
+
+/**
+ * Build the Cognito hosted-UI redirect for sign-in initiation: validate the
+ * requested redirect URL, mint a state token + nonce, and return the Cognito
+ * authorize URL (carrying the signed state) plus the httpOnly state cookie.
+ */
+export const buildLoginRedirect = (redirectUrl: string | undefined): {location: string; stateCookie: string} => {
+    if (!redirectUrl) {
+        throw new BadRequestError('Missing redirect_url parameter');
+    }
+
+    const validatedRedirectUrl = validateRedirectUrl(redirectUrl);
+    if (!validatedRedirectUrl) {
+        throw new BadRequestError('Invalid redirect_url parameter');
+    }
+
+    const {token, nonce} = mintStateToken({redirect_url: validatedRedirectUrl});
+
+    const {domain, clientId, redirectUri} = config.get('cognito');
+    const authorizeUrl = new URL(`https://${domain}/oauth2/authorize`);
+    authorizeUrl.searchParams.set('client_id', clientId);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('scope', COGNITO_OAUTH_SCOPE);
+    authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+    authorizeUrl.searchParams.set('state', token);
+
+    return {location: authorizeUrl.toString(), stateCookie: buildStateCookie(nonce)};
+};
+
+/**
+ * Handle the OAuth callback: verify the signed state token + nonce BEFORE
+ * exchanging the authorization code, then validate the redirect target. Throws
+ * (and never reaches the token exchange) when the state is missing, forged or
+ * expired — this ordering is the security crux of the login-CSRF protection.
+ */
+export const handleOAuthCallback = async (params: {
+    code: string | undefined;
+    state: string | undefined;
+    oauthStateNonce: string | null;
+}): Promise<{cookies: string[]; redirectUrl: string}> => {
+    const {code, state, oauthStateNonce} = params;
+
+    if (!code) {
+        throw new BadRequestError('Missing authorization code');
+    }
+    if (!state) {
+        throw new BadRequestError('Missing state parameter');
+    }
+
+    // SECURITY: validate the signed state + nonce before any upstream token exchange.
+    const verifiedState = verifyStateToken(state, oauthStateNonce);
+    if (!verifiedState) {
+        throw new ForbiddenError('Invalid or expired OAuth state');
+    }
+
+    const validatedRedirectUrl = validateRedirectUrl(verifiedState.redirect_url);
+    if (!validatedRedirectUrl) {
+        throw new BadRequestError('Invalid redirect_url in state');
+    }
+
+    // Only after the state is verified do we exchange the authorization code.
+    const {cookies} = await exchangeCodeForTokens(code);
+    return {cookies, redirectUrl: validatedRedirectUrl};
 };

--- a/apps/api/src/domains/auth/auth.routes.ts
+++ b/apps/api/src/domains/auth/auth.routes.ts
@@ -1,56 +1,51 @@
-import {exchangeCodeForTokens, generateWsToken, refreshTokens} from '@/domains/auth/auth.controller';
+import {buildLoginRedirect, generateWsToken, handleOAuthCallback, refreshTokens} from '@/domains/auth/auth.controller';
 import {validateRedirectUrl} from '@/domains/auth/auth.helpers';
 import {addUserIntegrationsToCtx} from '@/domains/integrations/integrations.middleware';
-import {buildClearCookies, extractTokenFromCookies} from '@/shared/helpers/cookies';
+import {buildClearCookies, buildClearStateCookie, extractTokenFromCookies, OAUTH_STATE_COOKIE_NAME} from '@/shared/helpers/cookies';
 import {getLogger} from '@/shared/logger';
 import {AppRequestContext} from '@/shared/types';
 import {BadRequestError, ForbiddenError, HttpStatusCodes, Router, UnauthorizedError} from '@aws-lambda-powertools/event-handler/http';
-import {State} from '@gitgazer/db/types';
 import {APIGatewayProxyEventV2} from 'aws-lambda';
 
 const router = new Router();
+
+router.get('/api/auth/login', async (reqCtx: AppRequestContext) => {
+    const logger = getLogger();
+    logger.info('OAuth login initiation handler invoked');
+
+    const event = reqCtx.event as APIGatewayProxyEventV2;
+    const {location, stateCookie} = buildLoginRedirect(event.queryStringParameters?.redirect_url);
+
+    return new Response(null, {
+        status: HttpStatusCodes.FOUND,
+        headers: {
+            Location: location,
+            'Set-Cookie': stateCookie,
+        },
+    });
+});
 
 router.get('/api/auth/callback', async (reqCtx: AppRequestContext) => {
     const logger = getLogger();
     logger.info('OAuth callback handler invoked');
 
-    const code = reqCtx.event.queryStringParameters?.code;
-    const state = reqCtx.event.queryStringParameters?.state;
+    const event = reqCtx.event as APIGatewayProxyEventV2;
+    const code = event.queryStringParameters?.code;
+    const state = event.queryStringParameters?.state;
+    const oauthStateNonce = extractTokenFromCookies(event.cookies, OAUTH_STATE_COOKIE_NAME);
 
-    if (!code) {
-        throw new BadRequestError('Missing authorization code');
-    }
-
-    if (!state) {
-        throw new BadRequestError('Missing state parameter');
-    }
-
-    logger.debug('Exchanging authorization code for tokens', {state});
-
-    const {cookies} = await exchangeCodeForTokens(code);
-
-    // Decode state parameter (base64-encoded JSON)
-    const decodedState = Buffer.from(state, 'base64').toString('utf-8');
-    const stateData = JSON.parse(decodedState) as State;
-
-    if (!stateData.redirect_url) {
-        throw new BadRequestError('Missing redirect_url in state');
-    }
-
-    const validatedRedirectUrl = validateRedirectUrl(stateData.redirect_url);
-    if (!validatedRedirectUrl) {
-        throw new BadRequestError('Invalid redirect_url in state');
-    }
+    // Verify the signed state + nonce BEFORE exchanging the code (see handleOAuthCallback).
+    const {cookies, redirectUrl} = await handleOAuthCallback({code, state, oauthStateNonce});
 
     logger.info('OAuth callback successful, redirecting to frontend', {
-        frontendUrl: validatedRedirectUrl,
+        frontendUrl: redirectUrl,
     });
 
     return new Response(null, {
         status: HttpStatusCodes.FOUND,
         headers: {
-            Location: validatedRedirectUrl,
-            'Set-Cookie': cookies.join(', '),
+            Location: redirectUrl,
+            'Set-Cookie': [...cookies, buildClearStateCookie()].join(', '),
         },
     });
 });
@@ -148,6 +143,6 @@ router.get('/api/auth/ws-token', [addUserIntegrationsToCtx], async (reqCtx: AppR
     });
 });
 
-export const publicPrefixes = ['/api/auth/cognito/', '/api/auth/callback', '/api/auth/refresh'] as const;
+export const publicPrefixes = ['/api/auth/cognito/', '/api/auth/login', '/api/auth/callback', '/api/auth/refresh'] as const;
 
 export default router;

--- a/apps/api/src/shared/config.ts
+++ b/apps/api/src/shared/config.ts
@@ -137,6 +137,13 @@ const config = convict({
         env: 'WS_TOKEN_SECRET',
         sensitive: true,
     },
+    stateSecret: {
+        doc: 'Dedicated HMAC key for signing OAuth state tokens (CSRF nonce binding for the login flow)',
+        format: String,
+        default: '',
+        env: 'STATE_SECRET',
+        sensitive: true,
+    },
     webhookQueueUrl: {
         doc: 'SQS queue URL for async webhook event processing',
         format: String,

--- a/apps/api/src/shared/helpers/cookies.test.ts
+++ b/apps/api/src/shared/helpers/cookies.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, it} from 'vitest';
+
+import {buildClearStateCookie, buildStateCookie, extractTokenFromCookies, OAUTH_STATE_COOKIE_NAME} from './cookies';
+
+describe('buildStateCookie', () => {
+    it('builds an httpOnly, secure, lax, short-lived state cookie', () => {
+        const cookie = buildStateCookie('nonce-123');
+
+        expect(cookie).toContain(`${OAUTH_STATE_COOKIE_NAME}=nonce-123`);
+        expect(cookie).toContain('HttpOnly');
+        expect(cookie).toContain('Secure');
+        expect(cookie).toContain('SameSite=Lax');
+        expect(cookie).toContain('Path=/');
+        expect(cookie).toContain('Max-Age=600');
+    });
+});
+
+describe('buildClearStateCookie', () => {
+    it('clears the state cookie with Max-Age=0', () => {
+        const cookie = buildClearStateCookie();
+
+        expect(cookie).toContain(`${OAUTH_STATE_COOKIE_NAME}=;`);
+        expect(cookie).toContain('Max-Age=0');
+        expect(cookie).toContain('HttpOnly');
+    });
+});
+
+describe('extractTokenFromCookies', () => {
+    it('extracts the state nonce from the cookie header', () => {
+        const nonce = extractTokenFromCookies([`${OAUTH_STATE_COOKIE_NAME}=noncevalue`], OAUTH_STATE_COOKIE_NAME);
+
+        expect(nonce).toBe('noncevalue');
+    });
+
+    it('returns null when the state cookie is absent', () => {
+        expect(extractTokenFromCookies(['other=1'], OAUTH_STATE_COOKIE_NAME)).toBeNull();
+        expect(extractTokenFromCookies(undefined, OAUTH_STATE_COOKIE_NAME)).toBeNull();
+    });
+});

--- a/apps/api/src/shared/helpers/cookies.ts
+++ b/apps/api/src/shared/helpers/cookies.ts
@@ -4,6 +4,10 @@
 
 const COOKIE_OPTIONS = 'Secure; HttpOnly; SameSite=Lax; Path=/';
 const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+const STATE_COOKIE_MAX_AGE = 600; // 10 minutes — short-lived OAuth state nonce
+
+/** Cookie name holding the OAuth state nonce that binds the signed state token to the browser. */
+export const OAUTH_STATE_COOKIE_NAME = 'oauthState';
 
 export function extractTokenFromCookies(cookies: string[] | undefined, tokenName: string): string | null {
     if (!cookies || cookies.length === 0) {
@@ -38,4 +42,17 @@ export function buildAuthCookies(tokens: {access_token: string; id_token: string
 
 export function buildClearCookies(): string[] {
     return [`accessToken=; ${COOKIE_OPTIONS}; Max-Age=0`, `idToken=; ${COOKIE_OPTIONS}; Max-Age=0`, `refreshToken=; ${COOKIE_OPTIONS}; Max-Age=0`];
+}
+
+/**
+ * Build the short-lived httpOnly cookie holding the OAuth state nonce.
+ * `SameSite=Lax` is required so the cookie is returned on the top-level GET
+ * navigation back from the Cognito hosted UI to the callback endpoint.
+ */
+export function buildStateCookie(nonce: string): string {
+    return `${OAUTH_STATE_COOKIE_NAME}=${nonce}; ${COOKIE_OPTIONS}; Max-Age=${STATE_COOKIE_MAX_AGE}`;
+}
+
+export function buildClearStateCookie(): string {
+    return `${OAUTH_STATE_COOKIE_NAME}=; ${COOKIE_OPTIONS}; Max-Age=0`;
 }

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,8 +1,6 @@
 import {parseApiResponse} from '@/utils/apiResponse';
-import {isUserAttributes, State, UserAttributes} from '@common/types';
+import {isUserAttributes, UserAttributes} from '@common/types';
 
-const COGNITO_DOMAIN = import.meta.env.VITE_COGNITO_DOMAIN;
-const COGNITO_CLIENT_ID = import.meta.env.VITE_COGNITO_USER_POOL_CLIENT_ID;
 const API_ENDPOINT = import.meta.env.VITE_REST_API_ENDPOINT;
 
 let cachedUserAttributes: UserAttributes | null = null;
@@ -127,23 +125,10 @@ export const useAuth = () => {
     };
 
     const signIn = () => {
-        const authUrl = `https://${COGNITO_DOMAIN}/oauth2/authorize`;
-
-        // Encode the current origin in state parameter for dynamic redirect
+        // Initiate sign-in through the backend so it can mint a server-bound state
+        // nonce, set the httpOnly state cookie, and redirect to the Cognito hosted UI.
         const redirectUrl = window.location.origin;
-
-        const state: State = {redirect_url: redirectUrl};
-        const stateEncoded = btoa(JSON.stringify(state));
-
-        const params = new URLSearchParams({
-            client_id: COGNITO_CLIENT_ID,
-            response_type: 'code',
-            scope: 'email openid profile aws.cognito.signin.user.admin',
-            redirect_uri: `${API_ENDPOINT}/auth/callback`,
-            state: stateEncoded,
-        });
-
-        window.location.href = `${authUrl}?${params.toString()}`;
+        window.location.href = `${API_ENDPOINT}/auth/login?redirect_url=${encodeURIComponent(redirectUrl)}`;
     };
 
     const signOut = () => {


### PR DESCRIPTION
…xchange

Replace the unauthenticated, client-built OAuth state (base64 JSON with only redirect_url) with a server-minted, HMAC-signed state token bound to a short-lived httpOnly nonce cookie, closing the login-CSRF gap (OWASP A01/A04).

config: add dedicated stateSecret (STATE_SECRET) HMAC key. auth.controller: add mintStateToken/verifyStateToken (constant-time, exp + nonce checks) plus thin testable buildLoginRedirect/handleOAuthCallback. auth.routes: new GET /api/auth/login initiation endpoint; callback verifies state+nonce BEFORE exchanging the code, clears the state cookie, and no longer logs state. cookies: add buildStateCookie/buildClearStateCookie. web/useAuth: signIn navigates to the backend initiation endpoint.

Tests assert exchangeCodeForTokens is never reached for missing/forged/expired nonces.