### PR TITLE
fix(deps): collapse @types/node to a single version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,6 @@ catalogs:
     '@types/convict':
       specifier: ^6.1.6
       version: 6.1.6
-    '@types/node':
-      specifier: ^26.1.2
-      version: 26.2.0
     '@types/pg':
       specifier: ^8.21.0
       version: 8.21.0
@@ -229,6 +226,9 @@ catalogs:
       specifier: ^3.3.8
       version: 3.3.9
 
+overrides:
+  '@types/node': ^26.1.2
+
 importers:
 
   .:
@@ -243,7 +243,7 @@ importers:
         specifier: 'catalog:'
         version: 23.1.1(@babel/traverse@7.29.8(supports-color@7.2.0))(@nx/eslint@23.1.1(@babel/traverse@7.29.8(supports-color@7.2.0))(@swc/core@1.15.47(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(nx@23.1.1(@swc/core@1.15.47(@swc/helpers@0.5.23)))(supports-color@7.2.0))(@swc/core@1.15.47(@swc/helpers@0.5.23))(nx@23.1.1(@swc/core@1.15.47(@swc/helpers@0.5.23)))(supports-color@7.2.0)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vitest@4.1.10)
       '@types/node':
-        specifier: 'catalog:'
+        specifier: ^26.1.2
         version: 26.2.0
       '@typescript-eslint/eslint-plugin':
         specifier: 'catalog:'
@@ -3993,9 +3993,6 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-
-  '@types/node@17.0.45':
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
@@ -8831,7 +8828,7 @@ packages:
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
+      '@types/node': ^26.1.2
       typescript: '>=2.7'
     peerDependenciesMeta:
       '@swc/core':
@@ -9085,7 +9082,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^26.1.2
       '@vitejs/devtools': ^0.4.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
@@ -9130,7 +9127,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@types/node': ^26.1.2
       '@vitest/browser-playwright': 4.1.10
       '@vitest/browser-preview': 4.1.10
       '@vitest/browser-webdriverio': 4.1.10
@@ -14503,8 +14500,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@17.0.45': {}
-
   '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
@@ -14548,7 +14543,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 26.2.0
 
   '@types/send@0.17.6':
     dependencies:
@@ -19791,7 +19786,7 @@ snapshots:
 
   sitemap@7.1.3:
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 26.2.0
       '@types/sax': 1.2.7
       arg: 5.0.2
       sax: 1.6.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,6 +81,16 @@ catalog:
   'vue-router': '^5.2.0'
   'vue-tsc': '^3.3.8'
 
+# sitemap@7 (via @docusaurus/plugin-sitemap) depends on @types/node ^17.0.5, which kept a second,
+# much older copy of it in the lockfile. Two @types/node versions means conflicting globals, and it
+# also tripped a dependabot-core bug: it read the stale copy as the current version of our catalog
+# entry, tried to re-apply a bump that was already in place, changed no files and failed the update
+# job with NoChangeError on every run. Collapsing to one version fixes both. Safe because
+# @types/node is types-only - nothing ships at runtime. 'catalog:' keeps this in step with the
+# catalog entry above, so a Dependabot bump there needs no change here.
+overrides:
+  '@types/node': 'catalog:'
+
 allowBuilds:
   '@swc/core': true
   core-js: true


### PR DESCRIPTION
sitemap@7, pulled in by @docusaurus/plugin-sitemap, depends on @types/node ^17.0.5. That kept a second, much older copy of @types/node in the lockfile alongside the 26.x our catalog resolves to.

Two @types/node versions in one workspace means conflicting globals. It also tripped a dependabot-core bug: Dependabot read the stale 17.0.45 as the current version of our catalog entry, tried to re-apply a bump that was already in place, wrote no files and failed the npm update job with NoChangeError. Nothing changed, so the same bump was retried on every scheduled run.

Override @types/node to the catalog version so only one copy resolves. Safe because it is types-only - nothing ships at runtime. Using 'catalog:' rather than a literal version keeps the override in step with the catalog entry, so a Dependabot bump there needs no change here.

Verified: no 17.0.45 left in the lockfile, --frozen-lockfile installs, typecheck and unit tests pass, and the docs build still emits a correct sitemap.xml.